### PR TITLE
Restore native context menu and enable Windows spell check

### DIFF
--- a/RefTextEditor/Source/RefTextEditor/Private/Spell/SpellChecker_Dummy.cpp
+++ b/RefTextEditor/Source/RefTextEditor/Private/Spell/SpellChecker_Dummy.cpp
@@ -1,5 +1,7 @@
 #include "Spell/SpellChecker.h"
 
+#if !REFTEXT_WINDOWS_SPELL
+
 class FDummySpellChecker : public ISpellChecker
 {
 public:
@@ -11,3 +13,5 @@ TSharedPtr<ISpellChecker> CreateSpellChecker()
 {
     return MakeShared<FDummySpellChecker>();
 }
+
+#endif // !REFTEXT_WINDOWS_SPELL

--- a/RefTextEditor/Source/RefTextEditor/Private/Spell/SpellChecker_Windows.cpp
+++ b/RefTextEditor/Source/RefTextEditor/Private/Spell/SpellChecker_Windows.cpp
@@ -1,0 +1,101 @@
+#if REFTEXT_WINDOWS_SPELL
+
+#include "Spell/SpellChecker.h"
+#include "Windows/AllowWindowsPlatformTypes.h"
+#include <wrl.h>
+#include <windows.h>
+#include <combaseapi.h>
+#include <spellcheck.h>
+#include "Windows/HideWindowsPlatformTypes.h"
+
+using Microsoft::WRL::ComPtr;
+
+static BSTR MakeBSTR(const FString& In)
+{
+    return ::SysAllocStringLen((const OLECHAR*)*In, In.Len());
+}
+
+class FWinSpellChecker : public ISpellChecker
+{
+public:
+    FWinSpellChecker()
+    {
+        // Initialize COM STA once for this module
+        CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+
+        ComPtr<ISpellCheckerFactory> Factory;
+        HRESULT hr = CoCreateInstance(CLSID_SpellCheckerFactory, nullptr, CLSCTX_INPROC_SERVER,
+                                      IID_PPV_ARGS(&Factory));
+        if (SUCCEEDED(hr) && Factory)
+        {
+            // Try user default first; if that fails, fall back to en-US
+            hr = Factory->CreateSpellChecker(nullptr, &Checker);
+            if (FAILED(hr) || !Checker)
+            {
+                Factory->CreateSpellChecker(L"en-US", &Checker);
+            }
+        }
+    }
+
+    virtual ~FWinSpellChecker() override
+    {
+        // Let COM uninitialize when module unloads; not strictly necessary here.
+    }
+
+    virtual bool Check(const FString& Word) override
+    {
+        if (!Checker) return true;
+
+        ComPtr<IEnumSpellingError> Errors;
+        TScopedBSTR TextBSTR(MakeBSTR(Word));
+        if (!TextBSTR) return true;
+
+        if (SUCCEEDED(Checker->Check(TextBSTR, &Errors)) && Errors)
+        {
+            ComPtr<ISpellingError> Err;
+            return !(Errors->Next(&Err) == S_OK); // true if NO error
+        }
+        return true; // assume ok if API failed
+    }
+
+    virtual void Suggest(const FString& Word, TArray<FString>& OutSuggestions) override
+    {
+        OutSuggestions.Reset();
+        if (!Checker) return;
+
+        ComPtr<IEnumString> Suggestions;
+        TScopedBSTR TextBSTR(MakeBSTR(Word));
+        if (!TextBSTR) return;
+
+        if (SUCCEEDED(Checker->Suggest(TextBSTR, &Suggestions)) && Suggestions)
+        {
+            LPOLESTR Item = nullptr;
+            ULONG Fetched = 0;
+            while (Suggestions->Next(1, &Item, &Fetched) == S_OK && Item)
+            {
+                OutSuggestions.Add(FString(Item));
+                CoTaskMemFree(Item);
+                Item = nullptr;
+            }
+        }
+    }
+
+private:
+    struct TScopedBSTR
+    {
+        BSTR Ptr{nullptr};
+        explicit TScopedBSTR(BSTR In) : Ptr(In) {}
+        ~TScopedBSTR(){ if(Ptr) ::SysFreeString(Ptr); }
+        operator BSTR() const { return Ptr; }
+        explicit operator bool() const { return Ptr != nullptr; }
+    };
+
+    ComPtr<ISpellChecker> Checker;
+};
+
+TSharedPtr<ISpellChecker> CreateSpellChecker()
+{
+    return MakeShared<FWinSpellChecker>();
+}
+
+#endif // REFTEXT_WINDOWS_SPELL

--- a/RefTextEditor/Source/RefTextEditor/Public/SRefTextEditor.h
+++ b/RefTextEditor/Source/RefTextEditor/Public/SRefTextEditor.h
@@ -24,8 +24,6 @@ private:
 	void ScheduleSpellScan(); // simple immediate call
 	void RunSpellScan();
 
-	// Context menu
-	TSharedPtr<class SWidget> MakeContextMenu();
-	void AddSelectionToDictionary();
-	bool IsWordInCustomDictionary(const FString& Word) const;
+        void AddSelectionToDictionary();
+        bool IsWordInCustomDictionary(const FString& Word) const;
 };

--- a/RefTextEditor/Source/RefTextEditor/RefTextEditor.Build.cs
+++ b/RefTextEditor/Source/RefTextEditor/RefTextEditor.Build.cs
@@ -33,7 +33,7 @@ public class RefTextEditor : ModuleRules
         if (Target.Platform == UnrealTargetPlatform.Win64)
         {
             PublicDefinitions.Add("REFTEXT_WINDOWS_SPELL=1");
-            PublicSystemLibraries.AddRange(new[] { "Ole32.lib", "OleAut32.lib" });
+            PublicSystemLibraries.AddRange(new[] { "Ole32.lib", "OleAut32.lib", "SpellCheck.lib" });
         }
     }
 }


### PR DESCRIPTION
## Summary
- Show UE's default right-click menu by removing custom override and moving "Add selection to dictionary" to a header menu
- Link against SpellCheck.lib and enable a Windows COM-based spell checker
- Guard dummy spell checker for non-Windows builds

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a22a39365c8332b8c3fdd755462d29