### PR TITLE
Fix Windows spellchecker compilation

### DIFF
--- a/RefTextEditor/Source/RefTextEditor/Private/SRefTextEditor.cpp
+++ b/RefTextEditor/Source/RefTextEditor/Private/SRefTextEditor.cpp
@@ -120,7 +120,7 @@ void SRefTextEditor::RunSpellScan()
 	const FString Text = GetText();
 	if (!Text.IsEmpty())
 	{
-		TSharedPtr<ISpellChecker> SC = CreateSpellChecker();
+                TSharedPtr<IRefSpellChecker> SC = CreateSpellChecker();
 		auto IsWord = [](TCHAR C) { return FChar::IsAlpha(C) || C == '\'' || C == '-'; };
 
 		int32 i = 0, N = Text.Len();

--- a/RefTextEditor/Source/RefTextEditor/Private/Spell/SpellChecker_Dummy.cpp
+++ b/RefTextEditor/Source/RefTextEditor/Private/Spell/SpellChecker_Dummy.cpp
@@ -2,14 +2,14 @@
 
 #if !REFTEXT_WINDOWS_SPELL
 
-class FDummySpellChecker : public ISpellChecker
+class FDummySpellChecker : public IRefSpellChecker
 {
 public:
     virtual bool Check(const FString&) override { return true; }
     virtual void Suggest(const FString&, TArray<FString>&) override {}
 };
 
-TSharedPtr<ISpellChecker> CreateSpellChecker()
+TSharedPtr<IRefSpellChecker> CreateSpellChecker()
 {
     return MakeShared<FDummySpellChecker>();
 }

--- a/RefTextEditor/Source/RefTextEditor/Private/Spell/SpellChecker_Windows.cpp
+++ b/RefTextEditor/Source/RefTextEditor/Private/Spell/SpellChecker_Windows.cpp
@@ -2,8 +2,8 @@
 
 #include "Spell/SpellChecker.h"
 #include "Windows/AllowWindowsPlatformTypes.h"
-#include <wrl.h>
 #include <windows.h>
+#include <wrl/client.h>
 #include <combaseapi.h>
 #include <spellcheck.h>
 #include "Windows/HideWindowsPlatformTypes.h"
@@ -15,7 +15,7 @@ static BSTR MakeBSTR(const FString& In)
     return ::SysAllocStringLen((const OLECHAR*)*In, In.Len());
 }
 
-class FWinSpellChecker : public ISpellChecker
+class FWinSpellChecker : public IRefSpellChecker
 {
 public:
     FWinSpellChecker()
@@ -90,10 +90,10 @@ private:
         explicit operator bool() const { return Ptr != nullptr; }
     };
 
-    ComPtr<ISpellChecker> Checker;
+    ComPtr<::ISpellChecker> Checker;
 };
 
-TSharedPtr<ISpellChecker> CreateSpellChecker()
+TSharedPtr<IRefSpellChecker> CreateSpellChecker()
 {
     return MakeShared<FWinSpellChecker>();
 }

--- a/RefTextEditor/Source/RefTextEditor/Public/Spell/SpellChecker.h
+++ b/RefTextEditor/Source/RefTextEditor/Public/Spell/SpellChecker.h
@@ -1,11 +1,13 @@
 #pragma once
 #include "Templates/SharedPointer.h"
 
-struct ISpellChecker : public TSharedFromThis<ISpellChecker>
+// Renamed from ISpellChecker to avoid clashing with the Windows
+// ISpellChecker COM interface exposed by <spellcheck.h>.
+struct IRefSpellChecker : public TSharedFromThis<IRefSpellChecker>
 {
-    virtual ~ISpellChecker() = default;
+    virtual ~IRefSpellChecker() = default;
     virtual bool Check(const FString& Word) = 0;
     virtual void Suggest(const FString& Word, TArray<FString>& OutSuggestions) = 0;
 };
 
-TSharedPtr<ISpellChecker> CreateSpellChecker();
+TSharedPtr<IRefSpellChecker> CreateSpellChecker();


### PR DESCRIPTION
## Summary
- avoid name clash with Windows ISpellChecker COM interface by renaming public spell checker abstraction to `IRefSpellChecker`
- adjust Windows implementation to include `<windows.h>` before WRL headers and use COM `ISpellChecker`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a22b93d4e483328c1e7e362a9903e6