### PR TITLE
Enable Windows 8 spellcheck API

### DIFF
--- a/RefTextEditor/Source/RefTextEditor/Private/Spell/SpellChecker_Windows.cpp
+++ b/RefTextEditor/Source/RefTextEditor/Private/Spell/SpellChecker_Windows.cpp
@@ -1,6 +1,15 @@
 #if REFTEXT_WINDOWS_SPELL
 
 #include "Spell/SpellChecker.h"
+
+// The Windows spell checking API was introduced in Windows 8.  Unreal's
+// Windows headers target Windows 7 by default which causes the interfaces in
+// <spellcheck.h> to be hidden.  Bump the target version so the required COM
+// types such as ISpellCheckerFactory are declared.
+#if !defined(_WIN32_WINNT) || _WIN32_WINNT < 0x0602
+#define _WIN32_WINNT 0x0602 // Windows 8
+#endif
+
 #include "Windows/AllowWindowsPlatformTypes.h"
 #include <windows.h>
 #include <wrl/client.h>


### PR DESCRIPTION
## Summary
- ensure Windows spellcheck COM interfaces are available by targeting Windows 8 in SpellChecker_Windows.cpp

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a22d360308833281e0a95659d93d1d