### PR TITLE
Avoid missing SpellCheck.lib during build

### DIFF
--- a/RefTextEditor/Source/RefTextEditor/Private/Spell/SpellChecker_Windows.cpp
+++ b/RefTextEditor/Source/RefTextEditor/Private/Spell/SpellChecker_Windows.cpp
@@ -14,6 +14,7 @@
 #include <windows.h>
 #include <wrl/client.h>
 #include <combaseapi.h>
+#include <initguid.h> // Define CLSID_SpellCheckerFactory without SpellCheck.lib
 #include <spellcheck.h>
 #include "Windows/HideWindowsPlatformTypes.h"
 

--- a/RefTextEditor/Source/RefTextEditor/RefTextEditor.Build.cs
+++ b/RefTextEditor/Source/RefTextEditor/RefTextEditor.Build.cs
@@ -33,7 +33,12 @@ public class RefTextEditor : ModuleRules
         if (Target.Platform == UnrealTargetPlatform.Win64)
         {
             PublicDefinitions.Add("REFTEXT_WINDOWS_SPELL=1");
-            PublicSystemLibraries.AddRange(new[] { "Ole32.lib", "OleAut32.lib", "SpellCheck.lib" });
+            // The Windows spell checking COM interfaces live in SpellCheck.dll.
+            // They can be loaded dynamically via CoCreateInstance, so only the
+            // standard COM system libraries are required at link time.  Linking
+            // against the import library SpellCheck.lib may fail when the SDK
+            // does not provide it, so omit it here.
+            PublicSystemLibraries.AddRange(new[] { "Ole32.lib", "OleAut32.lib" });
         }
     }
 }


### PR DESCRIPTION
## Summary
- load Windows spell-check COM objects without linking to SpellCheck.lib
- define spell-check GUIDs in code by including `<initguid.h>`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a22e81390883328693a74f54f4a7d4