### PR TITLE
Add non-editable live preview synced with editor

### DIFF
--- a/RefTextEditor/Source/RefTextEditor/Public/SRefTextEditor.h
+++ b/RefTextEditor/Source/RefTextEditor/Public/SRefTextEditor.h
@@ -19,6 +19,7 @@ public:
 private:
         // UI
         TSharedPtr<class SMultiLineEditableTextBox> TextBox;
+        TSharedPtr<class SMultiLineEditableTextBox> PreviewBox;
         TSharedPtr<class STextBlock>               MisspellCounter;
 
         struct FMisspelling
@@ -37,6 +38,8 @@ private:
         // context menu helpers
         TSharedPtr<SWidget> OnContextMenuOpening();
         void ReplaceWord(const FMisspelling& Miss, const FString& NewWord);
+
+        void OnEditorScrolled(float NewScrollOffset);
 
         void AddSelectionToDictionary();
         bool IsWordInCustomDictionary(const FString& Word) const;


### PR DESCRIPTION
## Summary
- Add read-only live preview panel beside main text box
- Mirror editor text in preview and synchronize scrolling

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68a245db4c9483328e4ae3ec18f7559d