### PR TITLE
Remove deprecated text box APIs for UE5.4

### DIFF
--- a/RefTextEditor/Source/RefTextEditor/Public/SRefTextEditor.h
+++ b/RefTextEditor/Source/RefTextEditor/Public/SRefTextEditor.h
@@ -37,9 +37,7 @@ private:
 
         // context menu helpers
         TSharedPtr<SWidget> OnContextMenuOpening();
-        void ReplaceWord(const FMisspelling& Miss, const FString& NewWord);
-
-        void OnEditorScrolled(float NewScrollOffset);
+        void ReplaceWord(FMisspelling Miss, FString NewWord);
 
         void AddSelectionToDictionary();
         bool IsWordInCustomDictionary(const FString& Word) const;


### PR DESCRIPTION
## Summary
- drop calls to removed SMultiLineEditableTextBox functions
- update menu entry construction and drop deprecated highlight code

## Testing
- `g++ -c -IRefTextEditor/Source/RefTextEditor/Public RefTextEditor/Source/RefTextEditor/Private/SRefTextEditor.cpp` *(fails: Widgets/SCompoundWidget.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a24761cea48332a5a3182a07c8feb3