### PR TITLE
Fix menu entry argument order for Unreal plugin

### DIFF
--- a/RefTextEditor/Source/RefTextEditor/Private/SRefTextEditor.cpp
+++ b/RefTextEditor/Source/RefTextEditor/Private/SRefTextEditor.cpp
@@ -35,12 +35,12 @@ void SRefTextEditor::Construct(const FArguments&)
                                                         .OnClicked_Lambda([this]()
                                                         {
                                                                 FMenuBuilder Menu(true, nullptr);
-                                                                Menu.AddMenuEntry(
-                                                                        FUIAction(FExecuteAction::CreateSP(this, &SRefTextEditor::AddSelectionToDictionary)),
-                                                                        FText::FromString(TEXT("Add selection to dictionary")),
-                                                                        FText::FromString(TEXT("Treat the selected word as correct.")),
-                                                                        FSlateIcon()
-                                                                );
+                                                               Menu.AddMenuEntry(
+                                                                       FText::FromString(TEXT("Add selection to dictionary")),
+                                                                       FText::FromString(TEXT("Treat the selected word as correct.")),
+                                                                       FSlateIcon(),
+                                                                       FUIAction(FExecuteAction::CreateSP(this, &SRefTextEditor::AddSelectionToDictionary))
+                                                               );
                                                                 FSlateApplication::Get().PushMenu(
                                                                         AsShared(),
                                                                         FWidgetPath(),
@@ -259,22 +259,22 @@ TSharedPtr<SWidget> SRefTextEditor::OnContextMenuOpening()
                 SC->Suggest(Found->Word, Suggestions);
                 for (const FString& Sugg : Suggestions)
                 {
-                        Menu.AddMenuEntry(
-                                FUIAction(FExecuteAction::CreateSP(this, &SRefTextEditor::ReplaceWord, *Found, Sugg)),
-                                FText::FromString(Sugg),
-                                FText::FromString(TEXT("Replace with suggestion")),
-                                FSlateIcon()
-                        );
+                       Menu.AddMenuEntry(
+                               FText::FromString(Sugg),
+                               FText::FromString(TEXT("Replace with suggestion")),
+                               FSlateIcon(),
+                               FUIAction(FExecuteAction::CreateSP(this, &SRefTextEditor::ReplaceWord, *Found, Sugg))
+                       );
                 }
         }
 
         Menu.AddSeparator();
-        Menu.AddMenuEntry(
-                FUIAction(FExecuteAction::CreateSP(this, &SRefTextEditor::AddSelectionToDictionary)),
-                FText::FromString(TEXT("Add to dictionary")),
-                FText::FromString(TEXT("Treat this word as correct")),
-                FSlateIcon()
-        );
+       Menu.AddMenuEntry(
+               FText::FromString(TEXT("Add to dictionary")),
+               FText::FromString(TEXT("Treat this word as correct")),
+               FSlateIcon(),
+               FUIAction(FExecuteAction::CreateSP(this, &SRefTextEditor::AddSelectionToDictionary))
+       );
 
         return Menu.MakeWidget();
 }


### PR DESCRIPTION
## Summary
- adjust AddMenuEntry calls to use label, tooltip, icon, action order

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a248c1f11c833294cb928b092a631c