### PR TITLE
Split editor and preview; restore context menu

### DIFF
--- a/RefTextEditor/Source/RefTextEditor/Private/SRefTextEditor.cpp
+++ b/RefTextEditor/Source/RefTextEditor/Private/SRefTextEditor.cpp
@@ -5,9 +5,11 @@
 #include "Widgets/Text/STextBlock.h"
 #include "Widgets/SBoxPanel.h"
 #include "Widgets/Layout/SBorder.h"
+#include "Widgets/Layout/SSplitter.h"
 #include "Framework/Application/SlateApplication.h"
 #include "Framework/MultiBox/MultiBoxBuilder.h"
 #include "Framework/Text/TextLayout.h"
+#include "InputCoreTypes.h"
 
 #include "Spell/SpellChecker.h"
 #include "RefTextEditorSettings.h"
@@ -57,24 +59,21 @@ void SRefTextEditor::Construct(const FArguments&)
                                 + SVerticalBox::Slot().FillHeight(1.f).Padding(4)
                                 [
                                         SNew(SBorder)
-                                                .OnMouseButtonDown_Lambda([this](const FGeometry&, const FPointerEvent&)
+                                                .OnMouseButtonDown_Lambda([this](const FGeometry&, const FPointerEvent& MouseEvent)
                                                         {
                                                                 if (TextBox.IsValid())
                                                                 {
                                                                         FSlateApplication::Get().SetKeyboardFocus(TextBox, EFocusCause::Mouse);
+                                                                        if (MouseEvent.GetEffectingButton() == EKeys::LeftMouseButton)
+                                                                        {
+                                                                                return FReply::Handled();
+                                                                        }
                                                                 }
-                                                                return FReply::Handled();
+                                                                return FReply::Unhandled();
                                                         })
                                                 [
-                                                        SNew(SHorizontalBox)
-                                                        + SHorizontalBox::Slot().FillWidth(1.f)
-                                                        [
-                                                                SAssignNew(PreviewBox, SMultiLineEditableTextBox)
-                                                                        .IsReadOnly(true)
-                                                                        .AlwaysShowScrollbars(true)
-                                                                        .AutoWrapText(true)
-                                                        ]
-                                                        + SHorizontalBox::Slot().FillWidth(1.f)
+                                                        SNew(SSplitter)
+                                                        + SSplitter::Slot().Value(0.5f)
                                                         [
                                                                 SAssignNew(TextBox, SMultiLineEditableTextBox)
                                                                         .IsReadOnly(false)
@@ -90,6 +89,13 @@ void SRefTextEditor::Construct(const FArguments&)
                                                                                         ScheduleSpellScan();
                                                                                 })
                                                                         .OnContextMenuOpening(FOnContextMenuOpening::CreateSP(this, &SRefTextEditor::OnContextMenuOpening))
+                                                        ]
+                                                        + SSplitter::Slot().Value(0.5f)
+                                                        [
+                                                                SAssignNew(PreviewBox, SMultiLineEditableTextBox)
+                                                                        .IsReadOnly(true)
+                                                                        .AlwaysShowScrollbars(true)
+                                                                        .AutoWrapText(true)
                                                         ]
                                                 ]
                                 ]


### PR DESCRIPTION
## Summary
- Replace side-by-side layout with a splitter to house the editor and preview in distinct panels
- Forward right-clicks to re-enable the text editor context menu

## Testing
- `clang++-20 -fsyntax-only Source/RefTextEditor/Private/SRefTextEditor.cpp -I Source/RefTextEditor/Public -I Source/RefTextEditor/Private` *(fails: 'Widgets/SCompoundWidget.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a24baf49ec8332956430a832031345