### PR TITLE
Add master reference row structure and sample data table

### DIFF
--- a/RefTextEditor/Resources/MasterReferenceTable.json
+++ b/RefTextEditor/Resources/MasterReferenceTable.json
@@ -1,0 +1,10 @@
+{
+    "Example": {
+        "HardTable": "/Game/Example/ExampleTable.ExampleTable",
+        "SoftFolderOverride": { "Path": "/Game/Soft" },
+        "HardFolderOverride": { "Path": "/Game/Hard" },
+        "bIncludeInLeftPanel": true,
+        "ByteLimitPerCell": 2048,
+        "WarnThreshold": 1024
+    }
+}

--- a/RefTextEditor/Source/RefTextEditor/Public/MasterReferenceTable.h
+++ b/RefTextEditor/Source/RefTextEditor/Public/MasterReferenceTable.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/DataTable.h"
+#include "MasterReferenceTable.generated.h"
+
+/**
+ * Row describing a single referenced table entry.
+ */
+USTRUCT(BlueprintType)
+struct FMasterRefRow : public FTableRowBase
+{
+    GENERATED_BODY()
+
+    /** Data table containing hard references for this entry. */
+    UPROPERTY(EditAnywhere, Category="Reference")
+    TObjectPtr<UDataTable> HardTable = nullptr;
+
+    /** Optional folder to place generated soft assets in. */
+    UPROPERTY(EditAnywhere, Category="Reference")
+    FDirectoryPath SoftFolderOverride;
+
+    /** Optional folder to place generated hard assets in. */
+    UPROPERTY(EditAnywhere, Category="Reference")
+    FDirectoryPath HardFolderOverride;
+
+    /** Whether this entry should appear in the editor's left panel. */
+    UPROPERTY(EditAnywhere, Category="Reference")
+    bool bIncludeInLeftPanel = true;
+
+    /** Maximum allowed bytes for each cell. */
+    UPROPERTY(EditAnywhere, Category="Reference")
+    int32 ByteLimitPerCell = 0;
+
+    /** Threshold in bytes that will trigger a warning. */
+    UPROPERTY(EditAnywhere, Category="Reference")
+    int32 WarnThreshold = 0;
+};

--- a/RefTextEditor/Source/RefTextEditor/Public/RefTextEditorSettings.h
+++ b/RefTextEditor/Source/RefTextEditor/Public/RefTextEditorSettings.h
@@ -3,6 +3,8 @@
 #include "Engine/DeveloperSettings.h"
 #include "RefTextEditorSettings.generated.h"
 
+class UDataTable;
+
 /**
  * Project-level settings for Ref Text Editor.
  * Appears in Project Settings → Plugins → Ref Text Editor
@@ -13,8 +15,12 @@ class URefTextEditorSettings : public UDeveloperSettings
 	GENERATED_BODY()
 public:
 	// Words treated as correctly spelled (case-insensitive)
-	UPROPERTY(EditAnywhere, Config, Category = "Spell Check")
-	TArray<FString> CustomDictionary;
+        UPROPERTY(EditAnywhere, Config, Category = "Spell Check")
+        TArray<FString> CustomDictionary;
+
+        // Data table containing master reference information
+        UPROPERTY(EditAnywhere, Config, Category = "Master Reference")
+        TObjectPtr<UDataTable> MasterReferenceTable = nullptr;
 
 	// Utility to access current settings
 	static const URefTextEditorSettings* Get() { return GetDefault<URefTextEditorSettings>(); }


### PR DESCRIPTION
## Summary
- define `FMasterRefRow` struct for master reference entries
- expose `MasterReferenceTable` in editor settings
- provide example data table asset for testing

## Testing
- `pytest` (no tests found)

------
https://chatgpt.com/codex/tasks/task_e_68a293259f58833290069247ce957e7e