### PR TITLE
Exclude soft text assets from cooking

### DIFF
--- a/RefTextEditor/Config/DefaultGame.ini
+++ b/RefTextEditor/Config/DefaultGame.ini
@@ -1,0 +1,3 @@
+[/Script/UnrealEd.ProjectPackagingSettings]
++DirectoriesToNeverCook=(Path="/Game/Editor/Text")
+

--- a/RefTextEditor/Source/RefTextEditor/Private/RefBakeService.cpp
+++ b/RefTextEditor/Source/RefTextEditor/Private/RefBakeService.cpp
@@ -31,16 +31,28 @@ void FRefBakeService::EnsureMirrors(const FMasterRefRow& Ref)
         return;
     }
 
+    // Ensure the hard table resides in the intended hard directory if one was provided
+    if (!Ref.HardFolderOverride.Path.IsEmpty())
+    {
+        const FString HardTablePath = Ref.HardTable->GetOutermost()->GetName();
+        if (!HardTablePath.StartsWith(Ref.HardFolderOverride.Path))
+        {
+            UE_LOG(LogTemp, Warning, TEXT("Hard table %s is outside designated folder %s"), *HardTablePath, *Ref.HardFolderOverride.Path);
+            return;
+        }
+    }
+
     UScriptStruct* RowStruct = Ref.HardTable->GetRowStruct();
     if (!RowStruct)
     {
         return;
     }
 
+    const FString SoftRoot = TEXT("/Game/Editor/Text");
     FString TargetFolder = Ref.SoftFolderOverride.Path;
-    if (TargetFolder.IsEmpty())
+    if (TargetFolder.IsEmpty() || !TargetFolder.StartsWith(SoftRoot))
     {
-        TargetFolder = TEXT("/Game/RefText/Mirrors");
+        TargetFolder = SoftRoot;
     }
 
     const FString SoftName = Ref.HardTable->GetName() + TEXT("_Soft");

--- a/RefTextEditor/Source/RefTextEditor/Public/RefTextEditorSettings.h
+++ b/RefTextEditor/Source/RefTextEditor/Public/RefTextEditorSettings.h
@@ -7,12 +7,13 @@ class UDataTable;
 
 /**
  * Project-level settings for Ref Text Editor.
- * Appears in Project Settings → Plugins → Ref Text Editor
+ * Appears in Project Settings → Plugins → Ref Text Editor.
+ * Soft tables live under /Game/Editor/Text and are never cooked into builds.
  */
 UCLASS(config = EditorPerProjectUserSettings, defaultconfig, meta = (DisplayName = "Ref Text Editor"))
 class URefTextEditorSettings : public UDeveloperSettings
 {
-	GENERATED_BODY()
+        GENERATED_BODY()
 public:
 	// Words treated as correctly spelled (case-insensitive)
         UPROPERTY(EditAnywhere, Config, Category = "Spell Check")


### PR DESCRIPTION
## Summary
- Prevent `/Game/Editor/Text` assets from being cooked by adding a packaging rule
- Validate soft and hard table paths during mirror generation
- Document that soft tables live in editor-only directories and are never cooked

## Testing
- `npm test` *(fails: ENOENT, missing package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2a0fb40788332864eb33ffe9c2b81