### PR TITLE
feat: extend settings and integrate into editor

### DIFF
--- a/RefTextEditor/Source/RefTextEditor/Private/RefTextEditorModule.cpp
+++ b/RefTextEditor/Source/RefTextEditor/Private/RefTextEditorModule.cpp
@@ -128,18 +128,12 @@ private:
 
                 int32 Limit = 0;
                 int32 Warn = 0;
+                EOverflowPolicy Policy = EOverflowPolicy::ConvertToAssets;
                 if (const URefTextEditorSettings* Settings = URefTextEditorSettings::Get())
                 {
-                    if (UDataTable* Master = Settings->MasterReferenceTable)
-                    {
-                        TArray<FMasterRefRow*> Rows;
-                        Master->GetAllRows<FMasterRefRow>(TEXT("SizeLimits"), Rows);
-                        if (Rows.Num() > 0)
-                        {
-                            Limit = Rows[0]->ByteLimitPerCell;
-                            Warn = Rows[0]->WarnThreshold;
-                        }
-                    }
+                    Limit = Settings->ByteLimitPerCell;
+                    Warn = Settings->WarnThreshold;
+                    Policy = Settings->OverflowPolicy;
                 }
                 if (Limit <= 0)
                 {
@@ -156,9 +150,12 @@ private:
                 if (!bValid || Bytes > Limit)
                 {
                     Color = FLinearColor::Red;
-                    if (TSharedPtr<SRefTextEditor> Pinned = EditorWeak.Pin())
+                    if (Policy == EOverflowPolicy::ConvertToAssets)
                     {
-                        BakeService::ConvertEntryToAssets(Pinned->GetText());
+                        if (TSharedPtr<SRefTextEditor> Pinned = EditorWeak.Pin())
+                        {
+                            BakeService::ConvertEntryToAssets(Pinned->GetText());
+                        }
                     }
                 }
                 else if (Bytes > Warn)

--- a/RefTextEditor/Source/RefTextEditor/Private/SRefMasterTablePreview.cpp
+++ b/RefTextEditor/Source/RefTextEditor/Private/SRefMasterTablePreview.cpp
@@ -6,8 +6,6 @@
 #include "Framework/Application/SlateApplication.h"
 #include "IBakeService.h"
 #include "RefTextEditorSettings.h"
-#include "MasterReferenceTable.h"
-#include "Engine/DataTable.h"
 
 void SRefMasterTablePreview::Construct(const FArguments& InArgs)
 {
@@ -35,16 +33,8 @@ void SRefMasterTablePreview::SetText(const FString& InText)
     ByteLimit = 0;
     if (const URefTextEditorSettings* Settings = URefTextEditorSettings::Get())
     {
-        if (UDataTable* Master = Settings->MasterReferenceTable)
-        {
-            TArray<FMasterRefRow*> Rows;
-            Master->GetAllRows<FMasterRefRow>(TEXT("PreviewLimits"), Rows);
-            if (Rows.Num() > 0)
-            {
-                ByteLimit = Rows[0]->ByteLimitPerCell;
-                WarnThreshold = Rows[0]->WarnThreshold;
-            }
-        }
+        ByteLimit = Settings->ByteLimitPerCell;
+        WarnThreshold = Settings->WarnThreshold;
     }
     if (ListView.IsValid())
     {

--- a/RefTextEditor/Source/RefTextEditor/Private/SRefTextEditor.cpp
+++ b/RefTextEditor/Source/RefTextEditor/Private/SRefTextEditor.cpp
@@ -317,7 +317,8 @@ void SRefTextEditor::RunSpellScan()
         const FString Text = GetText();
         if (!Text.IsEmpty())
         {
-                TSharedPtr<IRefSpellChecker> SC = CreateSpellChecker();
+                const URefTextEditorSettings* Settings = URefTextEditorSettings::Get();
+                TSharedPtr<IRefSpellChecker> SC = CreateSpellChecker(Settings ? Settings->DefaultLanguage : FString());
                 auto IsWord = [](TCHAR C) { return FChar::IsAlpha(C) || C == '\'' || C == '-'; };
 
 		int32 i = 0, N = Text.Len();
@@ -428,7 +429,8 @@ TSharedPtr<SWidget> SRefTextEditor::OnContextMenuOpening()
 
         FMenuBuilder Menu(true, nullptr);
 
-        TSharedPtr<IRefSpellChecker> SC = CreateSpellChecker();
+        const URefTextEditorSettings* Settings = URefTextEditorSettings::Get();
+        TSharedPtr<IRefSpellChecker> SC = CreateSpellChecker(Settings ? Settings->DefaultLanguage : FString());
         if (SC.IsValid())
         {
                 TArray<FString> Suggestions;

--- a/RefTextEditor/Source/RefTextEditor/Private/Spell/SpellChecker_Dummy.cpp
+++ b/RefTextEditor/Source/RefTextEditor/Private/Spell/SpellChecker_Dummy.cpp
@@ -9,7 +9,7 @@ public:
     virtual void Suggest(const FString&, TArray<FString>&) override {}
 };
 
-TSharedPtr<IRefSpellChecker> CreateSpellChecker()
+TSharedPtr<IRefSpellChecker> CreateSpellChecker(const FString&)
 {
     return MakeShared<FDummySpellChecker>();
 }

--- a/RefTextEditor/Source/RefTextEditor/Private/Spell/SpellChecker_Windows.cpp
+++ b/RefTextEditor/Source/RefTextEditor/Private/Spell/SpellChecker_Windows.cpp
@@ -27,7 +27,7 @@ static BSTR MakeBSTR(const FString& In)
 class FWinSpellChecker : public IRefSpellChecker
 {
 public:
-    FWinSpellChecker()
+    FWinSpellChecker(const FString& InLanguage)
     {
         // Initialize COM STA once for this module
         CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
@@ -37,8 +37,8 @@ public:
                                       IID_PPV_ARGS(&Factory));
         if (SUCCEEDED(hr) && Factory)
         {
-            // Try user default first; if that fails, fall back to en-US
-            hr = Factory->CreateSpellChecker(nullptr, &Checker);
+            const wchar_t* Lang = InLanguage.IsEmpty() ? nullptr : *InLanguage;
+            hr = Factory->CreateSpellChecker(Lang, &Checker);
             if (FAILED(hr) || !Checker)
             {
                 Factory->CreateSpellChecker(L"en-US", &Checker);
@@ -102,9 +102,9 @@ private:
     ComPtr<::ISpellChecker> Checker;
 };
 
-TSharedPtr<IRefSpellChecker> CreateSpellChecker()
+TSharedPtr<IRefSpellChecker> CreateSpellChecker(const FString& Language)
 {
-    return MakeShared<FWinSpellChecker>();
+    return MakeShared<FWinSpellChecker>(Language);
 }
 
 #endif // REFTEXT_WINDOWS_SPELL

--- a/RefTextEditor/Source/RefTextEditor/Public/RefTextEditorSettings.h
+++ b/RefTextEditor/Source/RefTextEditor/Public/RefTextEditorSettings.h
@@ -10,12 +10,21 @@ class UDataTable;
  * Appears in Project Settings → Plugins → Ref Text Editor.
  * Soft tables live under /Game/Editor/Text and are never cooked into builds.
  */
+UENUM()
+enum class EOverflowPolicy : uint8
+{
+        ConvertToAssets,
+        Error
+};
+
 UCLASS(config = EditorPerProjectUserSettings, defaultconfig, meta = (DisplayName = "Ref Text Editor"))
 class URefTextEditorSettings : public UDeveloperSettings
 {
         GENERATED_BODY()
 public:
-	// Words treated as correctly spelled (case-insensitive)
+        URefTextEditorSettings();
+
+        // Words treated as correctly spelled (case-insensitive)
         UPROPERTY(EditAnywhere, Config, Category = "Spell Check")
         TArray<FString> CustomDictionary;
 
@@ -23,7 +32,41 @@ public:
         UPROPERTY(EditAnywhere, Config, Category = "Master Reference")
         TObjectPtr<UDataTable> MasterReferenceTable = nullptr;
 
-	// Utility to access current settings
-	static const URefTextEditorSettings* Get() { return GetDefault<URefTextEditorSettings>(); }
-	static URefTextEditorSettings* GetMutable() { return GetMutableDefault<URefTextEditorSettings>(); }
+        // Root folder for generated soft assets
+        UPROPERTY(EditAnywhere, Config, Category = "Paths")
+        FDirectoryPath SoftRoot;
+
+        // Root folder for hard reference tables
+        UPROPERTY(EditAnywhere, Config, Category = "Paths")
+        FDirectoryPath HardRoot;
+
+        // Threshold in bytes that triggers a warning
+        UPROPERTY(EditAnywhere, Config, Category = "Limits")
+        int32 WarnThreshold = 0;
+
+        // Maximum allowed bytes for each cell
+        UPROPERTY(EditAnywhere, Config, Category = "Limits")
+        int32 ByteLimitPerCell = 0;
+
+        // Action to take when text exceeds the byte limit
+        UPROPERTY(EditAnywhere, Config, Category = "Limits")
+        EOverflowPolicy OverflowPolicy = EOverflowPolicy::ConvertToAssets;
+
+        // Default language used for spell checking
+        UPROPERTY(EditAnywhere, Config, Category = "Localization")
+        FString DefaultLanguage;
+
+        // Utility to access current settings
+        static const URefTextEditorSettings* Get() { return GetDefault<URefTextEditorSettings>(); }
+        static URefTextEditorSettings* GetMutable() { return GetMutableDefault<URefTextEditorSettings>(); }
 };
+
+inline URefTextEditorSettings::URefTextEditorSettings()
+{
+        SoftRoot.Path = TEXT("/Game/Editor/Text");
+        HardRoot.Path = TEXT("/Game/RefText");
+        WarnThreshold = 48;
+        ByteLimitPerCell = 60;
+        OverflowPolicy = EOverflowPolicy::ConvertToAssets;
+        DefaultLanguage = TEXT("en-US");
+}

--- a/RefTextEditor/Source/RefTextEditor/Public/Spell/SpellChecker.h
+++ b/RefTextEditor/Source/RefTextEditor/Public/Spell/SpellChecker.h
@@ -10,4 +10,4 @@ struct IRefSpellChecker : public TSharedFromThis<IRefSpellChecker>
     virtual void Suggest(const FString& Word, TArray<FString>& OutSuggestions) = 0;
 };
 
-TSharedPtr<IRefSpellChecker> CreateSpellChecker();
+TSharedPtr<IRefSpellChecker> CreateSpellChecker(const FString& Language);


### PR DESCRIPTION
## Summary
- expand Ref Text Editor settings with path, limit, overflow, and language options
- use project settings in bake service and editor widgets
- allow spell checker language selection

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2a50022708332baade055ecbc5acf