### PR TITLE
Use soft pointer for master table

### DIFF
--- a/RefTextEditor/Source/RefTextEditor/Private/RefBakeService.cpp
+++ b/RefTextEditor/Source/RefTextEditor/Private/RefBakeService.cpp
@@ -152,7 +152,7 @@ void FRefBakeService::SyncTable(UDataTable* Table)
 bool FRefBakeService::Validate(const FString& In, int32 LimitBytes, FString* OutError) const
 {
     const URefTextEditorSettings* Settings = URefTextEditorSettings::Get();
-    UDataTable* Master = Settings ? Settings->MasterReferenceTable : nullptr;
+    UDataTable* Master = Settings ? Settings->MasterReferenceTable.LoadSynchronous() : nullptr;
 
     TSet<FString> Visiting;
 

--- a/RefTextEditor/Source/RefTextEditor/Private/RefTextEditorModule.cpp
+++ b/RefTextEditor/Source/RefTextEditor/Private/RefTextEditorModule.cpp
@@ -43,7 +43,7 @@ public:
         // Mirror hard tables into soft copies on startup
         if (const URefTextEditorSettings* Settings = URefTextEditorSettings::Get())
         {
-            if (UDataTable* Master = Settings->MasterReferenceTable)
+            if (UDataTable* Master = Settings->MasterReferenceTable.LoadSynchronous())
             {
                 Master->ForeachRow<FMasterRefRow>(TEXT("StartupMirrors"), [](const FMasterRefRow& Row)
                 {

--- a/RefTextEditor/Source/RefTextEditor/Private/SRefTextEditor.cpp
+++ b/RefTextEditor/Source/RefTextEditor/Private/SRefTextEditor.cpp
@@ -255,7 +255,7 @@ TArray<FString> SRefTextEditor::BuildTokenSuggestions() const
         const URefTextEditorSettings* Settings = URefTextEditorSettings::Get();
         if (!Settings) return Suggestions;
 
-        if (UDataTable* Master = Settings->MasterReferenceTable)
+        if (UDataTable* Master = Settings->MasterReferenceTable.LoadSynchronous())
         {
                 Master->ForeachRow<FMasterRefRow>(TEXT("TokenSuggestions"), [&Suggestions](const FMasterRefRow& Row)
                 {

--- a/RefTextEditor/Source/RefTextEditor/Public/RefTextEditorSettings.h
+++ b/RefTextEditor/Source/RefTextEditor/Public/RefTextEditorSettings.h
@@ -30,7 +30,7 @@ public:
 
         // Data table containing master reference information
         UPROPERTY(EditAnywhere, Config, Category = "Master Reference")
-        TObjectPtr<UDataTable> MasterReferenceTable = nullptr;
+        TSoftObjectPtr<UDataTable> MasterReferenceTable = nullptr;
 
         // Root folder for generated soft assets
         UPROPERTY(EditAnywhere, Config, Category = "Paths")


### PR DESCRIPTION
## Summary
- fix build by storing master reference table as `TSoftObjectPtr` to allow config spec
- load master table synchronously wherever accessed

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2a6a25fa0833281b01c00b0c5b052