### PR TITLE
Fix DataTable iteration and scrollbar arguments

### DIFF
--- a/RefTextEditor/Source/RefTextEditor/Private/RefBakeService.cpp
+++ b/RefTextEditor/Source/RefTextEditor/Private/RefBakeService.cpp
@@ -53,7 +53,7 @@ void FRefBakeService::EnsureMirrors(const FMasterRefRow& Ref)
         return;
     }
 
-    UScriptStruct* RowStruct = Ref.HardTable->GetRowStruct();
+    const UScriptStruct* RowStruct = Ref.HardTable->GetRowStruct();
     if (!RowStruct)
     {
         return;
@@ -77,7 +77,7 @@ void FRefBakeService::EnsureMirrors(const FMasterRefRow& Ref)
         FAssetRegistryModule::AssetCreated(SoftTable);
     }
 
-    SoftTable->RowStruct = RowStruct;
+    SoftTable->RowStruct = const_cast<UScriptStruct*>(RowStruct);
     SoftTable->EmptyTable();
 
     for (const TPair<FName, uint8*>& Pair : Ref.HardTable->GetRowMap())
@@ -143,7 +143,7 @@ void FRefBakeService::SyncTable(UDataTable* Table)
         return;
     }
 
-    Table->ForeachRow<FTableRowBase>(TEXT("RefBakeSync"), [&](FTableRowBase& Row)
+    Table->ForeachRow<FTableRowBase>(TEXT("RefBakeSync"), [&](const FName& /*RowName*/, FTableRowBase& Row)
     {
         // Stub: each row could be processed/baked here
     });
@@ -212,7 +212,7 @@ bool FRefBakeService::Validate(const FString& In, int32 LimitBytes, FString* Out
             if (Master)
             {
                 UDataTable* TargetTable = nullptr;
-                Master->ForeachRow<FMasterRefRow>(TEXT("ValidateLookup"), [&](const FMasterRefRow& Ref)
+                Master->ForeachRow<FMasterRefRow>(TEXT("ValidateLookup"), [&](const FName&, const FMasterRefRow& Ref)
                 {
                     if (!TargetTable && Ref.HardTable && Ref.HardTable->GetName() == TableName)
                     {
@@ -240,7 +240,7 @@ bool FRefBakeService::Validate(const FString& In, int32 LimitBytes, FString* Out
                 }
                 const uint8* RowPtr = *RowPtrPtr;
 
-                UScriptStruct* RowStruct = TargetTable->GetRowStruct();
+                const UScriptStruct* RowStruct = TargetTable->GetRowStruct();
                 if (!RowStruct)
                 {
                     if (OutError)

--- a/RefTextEditor/Source/RefTextEditor/Private/RefTextEditorModule.cpp
+++ b/RefTextEditor/Source/RefTextEditor/Private/RefTextEditorModule.cpp
@@ -45,14 +45,14 @@ public:
         {
             if (UDataTable* Master = Settings->MasterReferenceTable.LoadSynchronous())
             {
-                Master->ForeachRow<FMasterRefRow>(TEXT("StartupMirrors"), [](const FMasterRefRow& Row)
+                Master->ForeachRow<FMasterRefRow>(TEXT("StartupMirrors"), [](const FName&, const FMasterRefRow& Row)
                 {
                     BakeService::EnsureMirrors(Row);
                 });
 
                 Master->OnDataTableChanged().AddLambda([Master](UDataTable*)
                 {
-                    Master->ForeachRow<FMasterRefRow>(TEXT("ChangedMirrors"), [](const FMasterRefRow& Row)
+                    Master->ForeachRow<FMasterRefRow>(TEXT("ChangedMirrors"), [](const FName&, const FMasterRefRow& Row)
                     {
                         BakeService::EnsureMirrors(Row);
                     });
@@ -105,8 +105,8 @@ private:
     TWeakPtr<SRefTextEditor> EditorWeak;
 
     TSharedRef<SRefTextEditor> Editor = SNew(SRefTextEditor)
-        .HScrollBar(HScrollBar)
-        .VScrollBar(VScrollBar)
+        .ExternalHScrollBar(HScrollBar)
+        .ExternalVScrollBar(VScrollBar)
         .OnTextChanged_Lambda([
             &Preview,
             &MasterPreview,


### PR DESCRIPTION
## Summary
- include row name parameter when iterating data tables
- use ExternalHScrollBar/VScrollBar arguments for SRefTextEditor
- make row struct pointers const-correct in bake service

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2a9b2067083328ad67ff7ca8cbd35