### PR TITLE
Fix delegate and row const correctness

### DIFF
--- a/RefTextEditor/Source/RefTextEditor/Private/RefBakeService.cpp
+++ b/RefTextEditor/Source/RefTextEditor/Private/RefBakeService.cpp
@@ -143,7 +143,7 @@ void FRefBakeService::SyncTable(UDataTable* Table)
         return;
     }
 
-    Table->ForeachRow<FTableRowBase>(TEXT("RefBakeSync"), [&](const FName& /*RowName*/, FTableRowBase& Row)
+    Table->ForeachRow<FTableRowBase>(TEXT("RefBakeSync"), [&](const FName& /*RowName*/, const FTableRowBase& Row)
     {
         // Stub: each row could be processed/baked here
     });

--- a/RefTextEditor/Source/RefTextEditor/Private/RefTextEditorModule.cpp
+++ b/RefTextEditor/Source/RefTextEditor/Private/RefTextEditorModule.cpp
@@ -50,7 +50,7 @@ public:
                     BakeService::EnsureMirrors(Row);
                 });
 
-                Master->OnDataTableChanged().AddLambda([Master](UDataTable*)
+                Master->OnDataTableChanged().AddLambda([Master]()
                 {
                     Master->ForeachRow<FMasterRefRow>(TEXT("ChangedMirrors"), [](const FName&, const FMasterRefRow& Row)
                     {


### PR DESCRIPTION
## Summary
- Ensure row lambdas use const references for `ForeachRow`
- Remove unused parameter from data-table change delegate binding

## Testing
- `python3 -m pytest` *(fails: No module named pytest)*
- `pip install pytest` *(fails: environment externally managed)*

------
https://chatgpt.com/codex/tasks/task_e_68a2ab3e2e6483328b58c35fdcbbbe66