### PR TITLE
Replace ellipsis glyph with ASCII dots

### DIFF
--- a/RefTextEditor/Source/RefTextEditor/Private/SRefTextEditor.cpp
+++ b/RefTextEditor/Source/RefTextEditor/Private/SRefTextEditor.cpp
@@ -37,11 +37,11 @@ void SRefTextEditor::Construct(const FArguments& InArgs)
 														.Text(FText::FromString(TEXT("Misspellings: 0")))
 										]
 										+ SHorizontalBox::Slot().AutoWidth().Padding(8,0,0,0).VAlign(VAlign_Center)
-										[
-												SNew(SButton)
-														.Text(FText::FromString(TEXT("⋯")))
-														.OnClicked_Lambda([this]()
-														{
+                                                                                [
+                                                                                                SNew(SButton)
+                                                                                                                .Text(FText::FromString(TEXT("...")))
+                                                                                                                .OnClicked_Lambda([this]()
+                                                                                                                {
 																FMenuBuilder Menu(true, nullptr);
 															   Menu.AddMenuEntry(
 																	   FText::FromString(TEXT("Add selection to dictionary")),


### PR DESCRIPTION
## Summary
- use standard triple dots in options button text to avoid fallback glyph issues

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2ad940c4883329353c2680ffa70be